### PR TITLE
Updated links for Ciphershastra

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,13 @@ A curated list of blockchain security Wargames, Challenges, and Capture the Flag
   * [Sharky CTF: Blockchain Level 0 to 4 Writeup](https://medium.com/zh3r0/sharky-ctf-blockchain-level-0-to-4-writeup-524b728709d0) by Nithilan Pugal
   * [Sharky CTF Blockchain Challenges](https://imagin.vip/?p=1380) by Imagin
 
-* [RazzorSec CTF](https://github.com/razzorsec/CTF)
-  * [HACON 2020](https://github.com/razzorsec/CTF/blob/master/HACON2020.md)
-  * [Sherlock](https://github.com/razzorsec/CTF/blob/master/Sherlock.md)
-  * [Minion](https://github.com/razzorsec/CTF/blob/master/Minion.md)
-  * [Shilpkaar](https://github.com/razzorsec/CTF/blob/master/Shilpkaar.md)
-  * [UnDeAD](https://github.com/razzorsec/CTF/blob/master/UnDeAD.md)
+* [CipherShastra CTF](https://ciphershastra.com/)
+  * [Sherlock](https://ciphershastra.com/sherlock.html)
+  * [Minion](https://ciphershastra.com/minion.html)
+  * [Limitless](https://ciphershastra.com/limitless.html)
+  * [Shilpkaar](https://ciphershastra.com/shilpkaar.html)
+  * [UnDeAD](https://ciphershastra.com/UnDeAD.html)
+  * [ThirtyFive](https://ciphershastra.com/ThirtyFive.html)
 
 * [Donjon CTF](https://donjon-ctf.io/) - 2020
   * [CTF 2020: Capture the Fortress](https://donjon.ledger.com/Capture-the-Fortress/)


### PR DESCRIPTION
Links for RazzorSec CTF challenges have been updated. The challenges are now being hosted on the CipherShastra Dapp!