### PR TITLE
Added Oak's CosmWasm CTF

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ A curated list of blockchain security Wargames, Challenges, and Capture the Flag
 
 ## CTFs and Writeups
 
+* [Oak Security's CosmWasm CTF](https://github.com/oak-security/cosmwasm-ctf) - AwesomWasm 2023
+  * [Capture The Flag ️Writeups — part 1](https://medium.com/oak-security/capture-the-flag-%EF%B8%8Fwriteups-awesomwasm-2023-pt-1-a40c6e506b49)
+  * [Capture The Flag ️Writeups — part 2](https://medium.com/oak-security/capture-the-flag-%EF%B8%8Fwriteups-awesomwasm-2023-pt-2-cb3e9b297c0)
+
 * [GPN CTF 2023](https://ctf.kitctf.de/)
   * [GPN CTF 2023 writeup](https://github.com/Kaiziron/gpnctf2023-writeup/blob/main/gambling.md) by Kaiziron
 


### PR DESCRIPTION
Hello,

To expand the Rust-based options I included the first-ever CosmWasm CTF run as an open competition back in July 2023 at AwesomWasm -CosmWasm conference.

I initially created a GH issue but realized that PRs seem like the default option for adding content to the list. Apologies if this is not the case.

Thanks!